### PR TITLE
fix: fixing import of APIError

### DIFF
--- a/omnidimension/__init__.py
+++ b/omnidimension/__init__.py
@@ -1,1 +1,2 @@
 from .client import Client
+from .client import APIError


### PR DESCRIPTION
a snippet from the official docs: 
---

![image](https://github.com/user-attachments/assets/97907254-33a5-4e69-8b8b-0125dff3e999)


## following the doc causes this **ERROR:**

```sh
app  |     from omnidimension import Client, APIError
app  | ImportError: cannot import name 'APIError' from 'omnidimension' (/app/.venv/lib/python3.12/site-packages/omnidimension/__init__.py)
```

--- 

## This PR fixes that issue
