### PR TITLE
docs: point MCP setup at the real servers, not the bundled one

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,6 @@ OmniDimension lets you **build, test, and deploy** reliable voice AI assistants 
 pip install omnidimension
 ````
 
-### With MCP Server Support
-
-```bash
-pip install omnidimension[mcp]
-```
-
 > Requires Python 3.9+
 
 ---
@@ -83,50 +77,36 @@ print(agents)
 
 ---
 
-## 🛰️ MCP Server Usage
+## 🛰️ MCP server
 
-You can run the MCP server in several ways:
+The OmniDimension MCP server lives in its own repositories, not in this SDK. Pick whichever fits your client.
 
-### 1. Using the Python module:
+### Hosted (no install)
 
-```bash
-python -m omnidimension.mcp_server --api-key your_api_key
+Point any MCP client at the hosted server. It speaks the standard OAuth flow, so clients discover the rest automatically:
+
+```
+https://mcp.omnidim.io/mcp
 ```
 
-### 2. Using the CLI entry point:
+For Claude Code:
 
 ```bash
-omnidim-mcp-server --api-key your_api_key
+claude mcp add --transport http omnidim https://mcp.omnidim.io/mcp --scope user
 ```
 
-### 3. Using the compatibility module (for MCP clients):
+Source: [Omnidim/omnidim-mcp-cloud](https://github.com/Omnidim/omnidim-mcp-cloud)
 
-```bash
-python -m omnidim_mcp_server --api-key your_api_key
-```
+### Local (stdio)
 
-You can also set the API key using the environment variable:
-
-```bash
-export OMNIDIM_API_KEY=your_api_key
-python -m omnidimension.mcp_server
-```
-
----
-
-## ⚙️ MCP Client Configuration
-
-To use OmniDimension with MCP clients like Claude Desktop, save the following configuration to a file named `omnidim_mcp.json`:
+For clients that launch a local server (Claude Desktop, Cursor, Windsurf), use the npm package [`@omnidim-ai/mcp-server`](https://www.npmjs.com/package/@omnidim-ai/mcp-server). Save this as your MCP client config:
 
 ```json
 {
   "mcpServers": {
-    "omnidim-mcp-server": {
-      "command": "python3",
-      "args": [
-        "-m",
-        "omnidim_mcp_server"
-      ],
+    "omnidim": {
+      "command": "npx",
+      "args": ["-y", "@omnidim-ai/mcp-server"],
       "env": {
         "OMNIDIM_API_KEY": "<your_omnidim_api_key>"
       }
@@ -134,6 +114,8 @@ To use OmniDimension with MCP clients like Claude Desktop, save the following co
   }
 }
 ```
+
+Source: [Omnidim/omnidim-mcp-server](https://github.com/Omnidim/omnidim-mcp-server)
 
 ---
 


### PR DESCRIPTION
The README told users to run the SDK's bundled MCP server (`python -m omnidimension.mcp_server` / `omnidim_mcp_server`), which is unmaintained and doesn't work.

Replaces the MCP sections with the two real, verified options:
- **Hosted:** `https://mcp.omnidim.io/mcp` (repo: Omnidim/omnidim-mcp-cloud) — verified live.
- **Local (stdio):** npm `@omnidim-ai/mcp-server` via `npx` (repo: Omnidim/omnidim-mcp-server) — verified published (v0.5.0).

Also drops the `pip install omnidimension[mcp]` install line.

**Not in this PR (needs your call):** the package still ships the broken bundled server, the `omnidim-mcp-server` console script, the `[mcp]` extra, `omnidim_mcp.json`, and a PyPI description that advertises it. Removing those is a published-package change (version bump + changelog), so I left it for a follow-up.